### PR TITLE
Add Gemini CLI integration to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,9 +27,13 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # Install Claude Code CLI globally using existing npm
 RUN npm install -g @anthropic-ai/claude-code
 
+# Install Gemini CLI globally using existing npm
+RUN npm install -g @google/gemini-cli
+
 # Configure direnv hook for bash and zsh
 RUN echo 'eval "$(direnv hook bash)"' >> ~/.bashrc \
     && echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+
 
 # Ensure uv is in PATH
 ENV PATH="/home/codespace/.cargo/bin:${PATH}"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,8 +6,9 @@
 #
 # Volumes:
 #   - gh-auth: Named volume for GitHub CLI credentials
-#   - claude-config: Named volume for Claude configuration
-#   - gemini-config: Named volume for Gemini configuration
+#
+# Note: Claude and Gemini configs are stored in /workspaces/.claude-config 
+#       and /workspaces/.gemini-config respectively for persistence
 #
 # Note: All services start automatically when devcontainer is opened
 #       (runServices defaults to all when not specified)
@@ -18,8 +19,6 @@
 
 volumes:
   gh-auth:
-  claude-config:
-  gemini-config:
 
 services:
   devcontainer:
@@ -28,12 +27,11 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ../..:/workspaces:cached
-      - claude-config:/home/codespace/.claude
-      - gemini-config:/home/codespace/.gemini
       - gh-auth:/home/codespace/.config/gh
     command: sleep infinity
     environment:
       - CLAUDE_CODE_ENABLE_TELEMETRY=1
+      - CLAUDE_CONFIG_DIR=/workspaces/.claude-config
       - OTEL_SERVICE_NAME=claude-code
       - OTEL_METRICS_EXPORTER=otlp
       - OTEL_LOGS_EXPORTER=otlp

--- a/.devcontainer/postCreateCommand/30-setup-gemini.sh
+++ b/.devcontainer/postCreateCommand/30-setup-gemini.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+echo "Setting up Gemini CLI configuration..."
+
+# Create Gemini config directory in workspaces if it doesn't exist
+mkdir -p /workspaces/.gemini-config
+
+# Create symlink from default location to workspaces for persistence
+if [ ! -L "/home/codespace/.gemini" ]; then
+    # Remove existing directory if it exists
+    if [ -d "/home/codespace/.gemini" ]; then
+        rm -rf /home/codespace/.gemini
+    fi
+    ln -s /workspaces/.gemini-config /home/codespace/.gemini
+fi
+
+# Create initial settings.json with OTLP telemetry configuration if it doesn't exist
+if [ ! -f "/workspaces/.gemini-config/settings.json" ]; then
+    cat > /workspaces/.gemini-config/settings.json << 'EOF'
+{
+  "telemetry": {
+    "enabled": true,
+    "target": "otlp",
+    "otlpEndpoint": "http://otlp:4318",
+    "serviceName": "gemini-cli"
+  }
+}
+EOF
+    echo "Created initial Gemini settings.json with OTLP configuration"
+fi
+
+# Ensure proper permissions
+chmod -R 755 /workspaces/.gemini-config
+chown -R codespace:codespace /workspaces/.gemini-config
+
+echo "Gemini CLI configuration setup complete!"

--- a/docs/tools/claude.md
+++ b/docs/tools/claude.md
@@ -1,0 +1,186 @@
+# Claude Code CLI Documentation
+
+## Overview
+Claude Code is Anthropic's official CLI for Claude, providing an interactive command-line interface for AI-assisted software engineering. It's installed globally in the devcontainer with persistent storage and telemetry configured.
+
+## Installation
+Claude Code is automatically installed when the devcontainer is built via:
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+## Configuration
+
+### Configuration Directory
+- **Location**: `/workspaces/.claude-config/`
+- **Environment Variable**: `CLAUDE_CONFIG_DIR=/workspaces/.claude-config`
+- **Purpose**: Stores API keys, settings, and session data across container rebuilds
+
+### Settings Files
+Claude Code uses multiple configuration files:
+- `~/.claude/settings.json` - User-specific settings
+- `.claude/settings.local.json` - Project-specific settings (in project root)
+
+### Environment Variables
+The following environment variables are configured in the devcontainer:
+- `CLAUDE_CONFIG_DIR=/workspaces/.claude-config` - Sets config directory
+- `CLAUDE_CODE_ENABLE_TELEMETRY=1` - Enables telemetry
+- `OTEL_SERVICE_NAME=claude-code` - Service name for telemetry
+- `OTEL_METRICS_EXPORTER=otlp` - Metrics exporter
+- `OTEL_LOGS_EXPORTER=otlp` - Logs exporter
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` - OTLP protocol
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://otlp:4318` - OTLP endpoint
+
+## Getting Started
+
+### First Time Setup
+1. Start the devcontainer
+2. Run `claude` from any directory
+3. Set your API key when prompted (or use environment variable)
+
+### API Key Configuration
+Set your API key using one of these methods:
+
+1. **Interactive Setup**:
+   ```bash
+   claude
+   # Follow prompts to enter API key
+   ```
+
+2. **Environment Variable**:
+   ```bash
+   export ANTHROPIC_API_KEY="your-api-key"
+   ```
+
+3. **Configuration File**:
+   Edit `~/.claude/settings.json`:
+   ```json
+   {
+     "apiKey": "your-api-key"
+   }
+   ```
+
+## Common Commands
+
+### Basic Usage
+```bash
+# Start Claude Code
+claude
+
+# Get help
+claude --help
+
+# Show version
+claude --version
+
+# Use a specific model
+claude --model claude-3-opus-20240229
+```
+
+### Session Management
+```bash
+# Resume last session
+claude --resume
+
+# Start with extended thinking
+claude --thinking
+
+# Enable verbose output
+claude --verbose
+```
+
+### File Operations
+```bash
+# Start with specific files
+claude file1.py file2.js
+
+# Start in a directory
+cd /path/to/project
+claude
+```
+
+## Telemetry
+Telemetry is automatically configured to send data to the local OTLP collector:
+- **Endpoint**: `http://otlp:4318`
+- **Service Name**: `claude-code`
+- **Data**: Traces, metrics, and logs
+
+To disable telemetry:
+1. Set environment variable: `CLAUDE_CODE_ENABLE_TELEMETRY=0`
+2. Or in settings.json:
+   ```json
+   {
+     "telemetry": {
+       "enabled": false
+     }
+   }
+   ```
+
+## MCP Servers
+Claude Code supports Model Context Protocol (MCP) servers for extending functionality. Configure them in:
+- `~/.claude/mcp.json` - Global MCP configuration
+- `.claude/mcp.json` - Project-specific MCP configuration
+
+Example MCP configuration:
+```json
+{
+  "servers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["@anthropic/mcp-server-filesystem", "/path/to/allowed/directory"]
+    }
+  }
+}
+```
+
+## Interactive Mode Features
+
+### Keyboard Shortcuts
+- `Ctrl+C` - Cancel current generation
+- `Ctrl+D` - Exit Claude Code
+- `Ctrl+L` - Clear screen
+- `Tab` - Autocomplete file paths
+
+### Slash Commands
+- `/help` - Show available commands
+- `/clear` - Clear conversation history
+- `/exit` - Exit Claude Code
+- `/model` - Switch model
+- `/settings` - View/edit settings
+
+## Persistence
+All Claude Code data persists in `/workspaces/.claude-config/`:
+- API keys
+- User settings
+- Conversation history
+- MCP server configurations
+
+This ensures your configuration is maintained across container rebuilds.
+
+## Troubleshooting
+
+### API Key Issues
+If Claude Code can't find your API key:
+1. Check if it's set: `echo $ANTHROPIC_API_KEY`
+2. Verify settings file: `cat /workspaces/.claude-config/settings.json`
+3. Re-run setup: `claude config set`
+
+### Telemetry Connection Issues
+If telemetry isn't working:
+1. Check OTLP collector status: `docker compose ps otlp`
+2. Verify endpoint connectivity: `curl http://otlp:4318`
+3. Check environment variables: `env | grep OTEL`
+
+### Permission Issues
+If you encounter permission errors:
+```bash
+# Fix permissions on config directory
+sudo chown -R codespace:codespace /workspaces/.claude-config
+chmod 700 /workspaces/.claude-config
+```
+
+## Additional Resources
+- [Official Documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [GitHub Repository](https://github.com/anthropics/claude-code)
+- [MCP Documentation](https://modelcontextprotocol.io/)
+- [Anthropic API Documentation](https://docs.anthropic.com/)

--- a/docs/tools/gemini.md
+++ b/docs/tools/gemini.md
@@ -1,0 +1,136 @@
+# Gemini CLI Documentation
+
+## Overview
+Gemini CLI is Google's open-source AI agent that brings the power of Gemini directly into your terminal. It's installed globally in the devcontainer and configured for persistent storage and telemetry.
+
+## Installation
+Gemini CLI is automatically installed when the devcontainer is built via:
+```bash
+npm install -g @google/gemini-cli
+```
+
+## Configuration
+
+### Configuration Directory
+- **Location**: `/workspaces/.gemini-config/`
+- **Symlink**: `~/.gemini` → `/workspaces/.gemini-config/`
+- **Purpose**: Ensures OAuth tokens and settings persist across container rebuilds
+
+### Settings File
+Configuration is stored in `/workspaces/.gemini-config/settings.json`:
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "target": "otlp",
+    "otlpEndpoint": "http://otlp:4318",
+    "serviceName": "gemini-cli"
+  }
+}
+```
+
+### Environment Variables
+Gemini CLI doesn't support a custom config directory environment variable, so we use a symlink approach. OTLP telemetry variables are inherited from the container environment.
+
+## Getting Started
+
+### First Time Setup
+1. Start the devcontainer
+2. Run `gemini` from any directory
+3. Sign in with your personal Google account when prompted
+4. You'll receive a free Gemini Code Assist license with:
+   - Access to Gemini 2.5 Pro
+   - 1 million token context window
+   - 60 model requests per minute
+   - 1,000 requests per day
+
+### Using an API Key (Optional)
+If you need higher request capacity:
+1. Generate a key from [Google AI Studio](https://makersuite.google.com/app/apikey)
+2. Set the environment variable:
+   ```bash
+   export GOOGLE_API_KEY="your-api-key"
+   ```
+
+## Common Commands
+
+### Basic Usage
+```bash
+# Start Gemini CLI
+gemini
+
+# Get help
+gemini --help
+
+# Use a specific model
+gemini --model gemini-1.5-pro-latest
+
+# Enable debug mode
+gemini --debug
+```
+
+### Project Commands
+```bash
+# Start in a specific project
+cd /path/to/project
+gemini
+
+# Enable sandbox mode (isolates tool execution)
+gemini --sandbox
+```
+
+## Telemetry
+Telemetry is automatically configured to send data to the local OTLP collector:
+- **Endpoint**: `http://otlp:4318`
+- **Service Name**: `gemini-cli`
+- **Data**: Traces, metrics, and logs (without prompts by default)
+
+To disable telemetry, edit `/workspaces/.gemini-config/settings.json`:
+```json
+{
+  "telemetry": {
+    "enabled": false
+  }
+}
+```
+
+## MCP Servers
+Gemini CLI supports Model Context Protocol (MCP) servers for extending functionality. Configure them in your project's `.gemini/mcp.json` file.
+
+## Persistence
+All Gemini CLI data persists in `/workspaces/.gemini-config/`:
+- OAuth tokens
+- User settings
+- Shell history (per project)
+- Temporary files
+
+This ensures you only need to authenticate once and your preferences are maintained across container rebuilds.
+
+## Troubleshooting
+
+### OAuth Token Issues
+If you're having authentication issues:
+1. Check if `/workspaces/.gemini-config/` exists and has proper permissions
+2. Try removing the directory and re-authenticating:
+   ```bash
+   rm -rf /workspaces/.gemini-config
+   rm -f ~/.gemini  # Remove symlink
+   gemini
+   ```
+
+### Configuration Not Loading
+Ensure the symlink exists:
+```bash
+ls -la ~/.gemini
+# Should show: .gemini -> /workspaces/.gemini-config
+```
+
+If missing, recreate it:
+```bash
+ln -s /workspaces/.gemini-config ~/.gemini
+```
+
+## Additional Resources
+- [Official GitHub Repository](https://github.com/google-gemini/gemini-cli)
+- [Google's Announcement Blog](https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/)
+- [Gemini API Documentation](https://ai.google.dev/)


### PR DESCRIPTION
## Summary
- Adds Google Gemini CLI alongside Claude Code in the devcontainer
- Configures persistent storage for OAuth tokens and settings
- Sets up OTLP telemetry integration for both tools

## Changes
- **Dockerfile**: Install `@google/gemini-cli` globally via npm
- **docker-compose.yml**: Add `CLAUDE_CONFIG_DIR` environment variable for persistent Claude config
- **Post-create script**: Set up Gemini config directory with symlink and OTLP settings
- **Documentation**: Add comprehensive guides for both tools in `/docs/tools/`

## Configuration Details
- Claude Code: Uses `CLAUDE_CONFIG_DIR=/workspaces/.claude-config`
- Gemini CLI: Uses symlink `~/.gemini` → `/workspaces/.gemini-config`
- Both tools send telemetry to `http://otlp:4318`

## Test Plan
- [ ] Rebuild devcontainer
- [ ] Run `gemini` and complete OAuth flow
- [ ] Run `claude` and verify it finds existing config
- [ ] Rebuild container again and verify auth persists
- [ ] Check OTLP collector receives telemetry from both tools

🤖 Generated with [Claude Code](https://claude.ai/code)